### PR TITLE
Improve handling of multiple inheritance + Raise error on undefined signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,6 @@ Changelog
 
 ### 1.2.2
 - Changed connect to raise error instead of warning upon undefined signal
+
+### 1.2.3
+- Added explicit metaclass for Connectable needed for resolving metaclass conflicts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,6 @@ Changelog
 
 ### 1.2.1
 - Fixed automatic signal inheritance for multiple base classes
+
+### 1.2.2
+- Changed connect to raise error instead of warning upon undefined signal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,5 @@ Changelog
 ### 1.2.0
 - Added support for automatic signal inheritance from base classes
 
+### 1.2.1
+- Fixed automatic signal inheritance for multiple base classes

--- a/connectable/__init__.py
+++ b/connectable/__init__.py
@@ -19,6 +19,6 @@ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFT
 OTHER DEALINGS IN THE SOFTWARE.
 
 """
-from .base import Connectable
+from .base import Connectable, UndefinedSignal
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/connectable/__init__.py
+++ b/connectable/__init__.py
@@ -21,4 +21,4 @@ OTHER DEALINGS IN THE SOFTWARE.
 """
 from .base import Connectable
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/connectable/__init__.py
+++ b/connectable/__init__.py
@@ -19,6 +19,6 @@ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFT
 OTHER DEALINGS IN THE SOFTWARE.
 
 """
-from .base import Connectable, UndefinedSignal
+from .base import Connectable, ConnectableMeta, UndefinedSignal
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"

--- a/connectable/base.py
+++ b/connectable/base.py
@@ -9,8 +9,8 @@ class CombineSignals(type):
     '''A meta class to automatically combine signals from base classes'''
 
     def __new__(metaclass, name, parents, class_dict, *kargs, **kwargs):
-        if 'signals' in class_dict and parents and getattr(parents[0], 'signals', None):
-            class_dict['signals'] = parents[0].signals + class_dict['signals']
+        class_dict['signals'] = set(s for p in parents for s in getattr(p, 'signals', ())) | \
+                set(class_dict.get('signals', ()))
 
         return super(CombineSignals, metaclass).__new__(metaclass, name, parents, class_dict, *kargs, **kwargs)
 

--- a/connectable/base.py
+++ b/connectable/base.py
@@ -15,6 +15,10 @@ class CombineSignals(type):
         return super(CombineSignals, metaclass).__new__(metaclass, name, parents, class_dict, *kargs, **kwargs)
 
 
+class UndefinedSignal(Exception):
+    pass
+
+
 class Connectable(object, metaclass=CombineSignals):
     __slots__ = ("connections")
     signals = ()
@@ -66,9 +70,8 @@ class Connectable(object, metaclass=CombineSignals):
            condition: only call the slot if the value emitted matches the required value or calling required returns True
         """
         if not signal in self.signals:
-            print("WARNING: {0} is trying to connect a slot to an undefined signal: {1}".format(self.__class__.__name__,
-                                                                                       str(signal)))
-            return
+            raise UndefinedSignal("{0} is trying to connect a slot to an undefined signal: {1}"
+                                  .format(self.__class__.__name__, str(signal)))
 
         if not hasattr(self, 'connections'):
             self.connections = {}

--- a/connectable/base.py
+++ b/connectable/base.py
@@ -15,11 +15,15 @@ class CombineSignals(type):
         return super(CombineSignals, metaclass).__new__(metaclass, name, parents, class_dict, *kargs, **kwargs)
 
 
+class ConnectableMeta(CombineSignals):
+    pass
+
+
 class UndefinedSignal(Exception):
     pass
 
 
-class Connectable(object, metaclass=CombineSignals):
+class Connectable(object, metaclass=ConnectableMeta):
     __slots__ = ("connections")
     signals = ()
 

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ except (IOError, ImportError, OSError, RuntimeError):
    readme = ''
 
 setup(name='connectable',
-      version='1.2.2',
+      version='1.2.3',
       description='A simple, yet powerful, implementation of QTs signal / slots pattern for Python3',
       long_description=readme,
       author='Timothy Crosley',

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ except (IOError, ImportError, OSError, RuntimeError):
    readme = ''
 
 setup(name='connectable',
-      version='1.2.1',
+      version='1.2.2',
       description='A simple, yet powerful, implementation of QTs signal / slots pattern for Python3',
       long_description=readme,
       author='Timothy Crosley',

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ except (IOError, ImportError, OSError, RuntimeError):
    readme = ''
 
 setup(name='connectable',
-      version='1.2.0',
+      version='1.2.1',
       description='A simple, yet powerful, implementation of QTs signal / slots pattern for Python3',
       long_description=readme,
       author='Timothy Crosley',

--- a/tests/test_connectable.py
+++ b/tests/test_connectable.py
@@ -19,7 +19,8 @@
     along with this program; if not, write to the Free Software
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 '''
-from connectable import Connectable
+import pytest
+from connectable import Connectable, UndefinedSignal
 
 function_called = False
 
@@ -56,7 +57,8 @@ def test_incorrect_signal_slot_connections():
     assert value1.emit("fake signal") == True
 
     #connect using fake signal
-    assert value1.connect("fake signal", value1.set_value) is None
+    with pytest.raises(UndefinedSignal):
+        assert value1.connect("fake signal", value1.set_value) is None
 
 
 def test_connect_without_condition():

--- a/tests/test_connectable.py
+++ b/tests/test_connectable.py
@@ -143,7 +143,7 @@ def test_disconnect():
     assert value2.value == 'It changes the value'
 
 
-class test_automatic_signal_inheritance():
+def test_automatic_signal_inheritance():
     '''A test to ensure signals auto inherit from parent classes'''
     class FirstInheritance(Value):
         signals = ('signalOne', )
@@ -156,5 +156,28 @@ class test_automatic_signal_inheritance():
     first = FirstInheritance('value')
     second = SecondInheritance('value')
 
-    assert first.signals == ('valueChanged', 'signalOne')
-    assert second.signals == ('valueChanged', 'signalOne', 'signalTwo')
+    assert first.signals == set(('valueChanged', 'signalOne'))
+    assert second.signals == set(('valueChanged', 'signalOne', 'signalTwo'))
+
+
+def test_automatic_signal_multiple_inheritance():
+    '''A test to ensure signals auto inherit from multiple parent classes'''
+    class FirstInheritance(Value):
+        signals = ('signalOne', )
+
+
+    class SecondInheritance(Value):
+        signals = ('signalTwo', )
+
+
+    class ThirdInheritance(FirstInheritance, SecondInheritance):
+        signals = ('signalThree', )
+
+
+    first = FirstInheritance('value')
+    second = SecondInheritance('value')
+    third = ThirdInheritance('value')
+
+    assert first.signals == set(('valueChanged', 'signalOne'))
+    assert second.signals == set(('valueChanged', 'signalTwo'))
+    assert third.signals == set(('valueChanged', 'signalOne', 'signalTwo', 'signalThree'))


### PR DESCRIPTION
I turned warnings for undefined signals into errors which is a breaking change however I don't see any benefit in allowing signals not to be defined. In particular, I made this change to get a stack trace as I was debugging a missing signal problem.